### PR TITLE
Changing HW lanes to start from 1 instead of 0

### DIFF
--- a/vendor/accton/as7512-32x/etc/opx/base_port_physical_mapping_table.xml
+++ b/vendor/accton/as7512-32x/etc/opx/base_port_physical_mapping_table.xml
@@ -14,195 +14,195 @@
 -->
 <front-panel>
 	<front-panel-port id="1" slot="0" npu="0" mac_offset="1" phy_media="1" breakout="false" name="e101-001-0">
-		<entry hwport="16" />
 		<entry hwport="17" />
 		<entry hwport="18" />
 		<entry hwport="19" />
+		<entry hwport="20" />
 	</front-panel-port>
 	<front-panel-port id="2" slot="0" npu="0" mac_offset="5" phy_media="2" breakout="false" name="e101-002-0">
-		<entry hwport="20" />
 		<entry hwport="21" />
 		<entry hwport="22" />
 		<entry hwport="23" />
+		<entry hwport="24" />
 	</front-panel-port>
 	<front-panel-port id="3" slot="0" npu="0" mac_offset="9" phy_media="3" breakout="false" name="e101-003-0">
-		<entry hwport="24" />
 		<entry hwport="25" />
 		<entry hwport="26" />
 		<entry hwport="27" />
+		<entry hwport="28" />
 	</front-panel-port>
 	<front-panel-port id="4" slot="0" npu="0" mac_offset="13" phy_media="4" breakout="false" name="e101-004-0">
-		<entry hwport="28" />
 		<entry hwport="29" />
 		<entry hwport="30" />
 		<entry hwport="31" />
+		<entry hwport="32" />
 	</front-panel-port>
 	<front-panel-port id="5" slot="0" npu="0" mac_offset="17" phy_media="5" breakout="false" name="e101-005-0">
-		<entry hwport="32" />
 		<entry hwport="33" />
 		<entry hwport="34" />
 		<entry hwport="35" />
+		<entry hwport="36" />
 	</front-panel-port>
 	<front-panel-port id="6" slot="0" npu="0" mac_offset="21" phy_media="6" breakout="false" name="e101-006-0">
-		<entry hwport="36" />
 		<entry hwport="37" />
 		<entry hwport="38" />
 		<entry hwport="39" />
+		<entry hwport="40" />
 	</front-panel-port>
 	<front-panel-port id="7" slot="0" npu="0" mac_offset="25" phy_media="7" breakout="false" name="e101-007-0">
-		<entry hwport="40" />
 		<entry hwport="41" />
 		<entry hwport="42" />
 		<entry hwport="43" />
+		<entry hwport="44" />
 	</front-panel-port>
 	<front-panel-port id="8" slot="0" npu="0" mac_offset="29" phy_media="8" breakout="false" name="e101-008-0">
-		<entry hwport="44" />
 		<entry hwport="45" />
 		<entry hwport="46" />
 		<entry hwport="47" />
+		<entry hwport="48" />
 	</front-panel-port>
 	<front-panel-port id="9" slot="0" npu="0" mac_offset="33" phy_media="9" breakout="false" name="e101-009-0">
-		<entry hwport="0" />
 		<entry hwport="1" />
 		<entry hwport="2" />
 		<entry hwport="3" />
+		<entry hwport="4" />
 	</front-panel-port>
 	<front-panel-port id="10" slot="0" npu="0" mac_offset="37" phy_media="10" breakout="false" name="e101-010-0">
-		<entry hwport="4" />
 		<entry hwport="5" />
 		<entry hwport="6" />
 		<entry hwport="7" />
+		<entry hwport="8" />
 	</front-panel-port>
 	<front-panel-port id="11" slot="0" npu="0" mac_offset="41" phy_media="11" breakout="false" name="e101-011-0">
-		<entry hwport="12" />
 		<entry hwport="13" />
 		<entry hwport="14" />
 		<entry hwport="15" />
+		<entry hwport="16" />
 	</front-panel-port>
 	<front-panel-port id="12" slot="0" npu="0" mac_offset="45" phy_media="12" breakout="false" name="e101-012-0">
-		<entry hwport="8" />
 		<entry hwport="9" />
 		<entry hwport="10" />
 		<entry hwport="11" />
+		<entry hwport="12" />
 	</front-panel-port>
 	<front-panel-port id="13" slot="0" npu="0" mac_offset="49" phy_media="13" breakout="false" name="e101-013-0">
-		<entry hwport="48" />
 		<entry hwport="49" />
 		<entry hwport="50" />
 		<entry hwport="51" />
+		<entry hwport="52" />
 	</front-panel-port>
 	<front-panel-port id="14" slot="0" npu="0" mac_offset="53" phy_media="14" breakout="false" name="e101-014-0">
-		<entry hwport="52" />
 		<entry hwport="53" />
 		<entry hwport="54" />
 		<entry hwport="55" />
+		<entry hwport="56" />
 	</front-panel-port>
 	<front-panel-port id="15" slot="0" npu="0" mac_offset="57" phy_media="15" breakout="false" name="e101-015-0">
-		<entry hwport="56" />
 		<entry hwport="57" />
 		<entry hwport="58" />
 		<entry hwport="59" />
+		<entry hwport="60" />
 	</front-panel-port>
 	<front-panel-port id="16" slot="0" npu="0" mac_offset="61" phy_media="16" breakout="false" name="e101-016-0">
-		<entry hwport="60" />
 		<entry hwport="61" />
 		<entry hwport="62" />
 		<entry hwport="63" />
+		<entry hwport="64" />
 	</front-panel-port>
 	<front-panel-port id="17" slot="0" npu="0" mac_offset="65" phy_media="17" breakout="false" name="e101-017-0">
-		<entry hwport="124" />
 		<entry hwport="125" />
 		<entry hwport="126" />
 		<entry hwport="127" />
+		<entry hwport="128" />
 	</front-panel-port>
 	<front-panel-port id="18" slot="0" npu="0" mac_offset="69" phy_media="18" breakout="false" name="e101-018-0">
-		<entry hwport="120" />
 		<entry hwport="121" />
 		<entry hwport="122" />
 		<entry hwport="123" />
+		<entry hwport="124" />
 	</front-panel-port>
 	<front-panel-port id="19" slot="0" npu="0" mac_offset="73" phy_media="19" breakout="false" name="e101-019-0">
-		<entry hwport="112" />
 		<entry hwport="113" />
 		<entry hwport="114" />
 		<entry hwport="115" />
+		<entry hwport="116" />
 	</front-panel-port>
 	<front-panel-port id="20" slot="0" npu="0" mac_offset="77" phy_media="20" breakout="false" name="e101-020-0">
-		<entry hwport="116" />
 		<entry hwport="117" />
 		<entry hwport="118" />
 		<entry hwport="119" />
+		<entry hwport="120" />
 	</front-panel-port>
 	<front-panel-port id="21" slot="0" npu="0" mac_offset="81" phy_media="21" breakout="false" name="e101-021-0">
-		<entry hwport="76" />
 		<entry hwport="77" />
 		<entry hwport="78" />
 		<entry hwport="79" />
+		<entry hwport="80" />
 	</front-panel-port>
 	<front-panel-port id="22" slot="0" npu="0" mac_offset="85" phy_media="22" breakout="false" name="e101-022-0">
-		<entry hwport="72" />
 		<entry hwport="73" />
 		<entry hwport="74" />
 		<entry hwport="75" />
+		<entry hwport="76" />
 	</front-panel-port>
 	<front-panel-port id="23" slot="0" npu="0" mac_offset="89" phy_media="23" breakout="false" name="e101-023-0">
-		<entry hwport="64" />
 		<entry hwport="65" />
 		<entry hwport="66" />
 		<entry hwport="67" />
+		<entry hwport="68" />
 	</front-panel-port>
 	<front-panel-port id="24" slot="0" npu="0" mac_offset="93" phy_media="24" breakout="false" name="e101-024-0">
-		<entry hwport="68" />
 		<entry hwport="69" />
 		<entry hwport="70" />
 		<entry hwport="71" />
+		<entry hwport="72" />
 	</front-panel-port>
 	<front-panel-port id="25" slot="0" npu="0" mac_offset="97" phy_media="25" breakout="false" name="e101-025-0">
-		<entry hwport="108" />
 		<entry hwport="109" />
 		<entry hwport="110" />
 		<entry hwport="111" />
+		<entry hwport="112" />
 	</front-panel-port>
 	<front-panel-port id="26" slot="0" npu="0" mac_offset="101" phy_media="26" breakout="false" name="e101-026-0">
-		<entry hwport="104" />
 		<entry hwport="105" />
 		<entry hwport="106" />
 		<entry hwport="107" />
+		<entry hwport="108" />
 	</front-panel-port>
 	<front-panel-port id="27" slot="0" npu="0" mac_offset="105" phy_media="27" breakout="false" name="e101-027-0">
-		<entry hwport="100" />
 		<entry hwport="101" />
 		<entry hwport="102" />
 		<entry hwport="103" />
+		<entry hwport="104" />
 	</front-panel-port>
 	<front-panel-port id="28" slot="0" npu="0" mac_offset="109" phy_media="28" breakout="false" name="e101-028-0">
-		<entry hwport="96" />
 		<entry hwport="97" />
 		<entry hwport="98" />
 		<entry hwport="99" />
+		<entry hwport="100" />
 	</front-panel-port>
 	<front-panel-port id="29" slot="0" npu="0" mac_offset="113" phy_media="29" breakout="false" name="e101-029-0">
-		<entry hwport="92" />
 		<entry hwport="93" />
 		<entry hwport="94" />
 		<entry hwport="95" />
+		<entry hwport="96" />
 	</front-panel-port>
 	<front-panel-port id="30" slot="0" npu="0" mac_offset="117" phy_media="30" breakout="false" name="e101-030-0">
-		<entry hwport="88" />
 		<entry hwport="89" />
 		<entry hwport="90" />
 		<entry hwport="91" />
+		<entry hwport="92" />
 	</front-panel-port>
 	<front-panel-port id="31" slot="0" npu="0" mac_offset="121" phy_media="31" breakout="false" name="e101-031-0">
-		<entry hwport="84" />
 		<entry hwport="85" />
 		<entry hwport="86" />
 		<entry hwport="87" />
+		<entry hwport="88" />
 	</front-panel-port>
 	<front-panel-port id="32" slot="0" npu="0" mac_offset="125" phy_media="32" breakout="false" name="e101-032-0">
-		<entry hwport="80" />
 		<entry hwport="81" />
 		<entry hwport="82" />
 		<entry hwport="83" />
+		<entry hwport="84" />
 	</front-panel-port>
 </front-panel>


### PR DESCRIPTION
I'm changing HW lanes mapping to start from 1, as expected by OPX NAS